### PR TITLE
Add per-project Airtable keys

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -141,6 +141,11 @@ class Project(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow)
     hide_dashboards = db.Column(db.Boolean, default=False)
+
+    # Optional Airtable configuration for this project
+    airtable_api_key = db.Column(db.String(100), nullable=True)
+    airtable_base_id = db.Column(db.String(50), nullable=True)
+    airtable_table_id = db.Column(db.String(50), nullable=True)
     
     parts = db.relationship('Part', backref='project', lazy=True)
     orders = db.relationship('Order', backref='project', lazy=True)

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -95,6 +95,23 @@ def update_project(project_id):
         'updated_at': project.updated_at.isoformat()
     })
 
+
+@app.route('/api/projects/<int:project_id>/airtable-keys', methods=['PUT'])
+@admin_required
+def update_project_airtable_keys(project_id):
+    """Update Airtable API credentials for a project (admin only)."""
+    project = Project.query.get_or_404(project_id)
+    data = request.json
+    if not data:
+        return jsonify(message="Error: No input data provided"), 400
+
+    project.airtable_api_key = data.get('airtable_api_key', project.airtable_api_key)
+    project.airtable_base_id = data.get('airtable_base_id', project.airtable_base_id)
+    project.airtable_table_id = data.get('airtable_table_id', project.airtable_table_id)
+
+    db.session.commit()
+    return jsonify(message="Airtable keys updated successfully")
+
 @app.route('/api/projects/<int:project_id>', methods=['DELETE'])
 @admin_required
 def delete_project(project_id):
@@ -444,7 +461,7 @@ def create_part():
                 # Conditions met: new_part.name should be an option for "Subsystem"
                 app.logger.info(f"Assembly '{new_part.name}' (ID: {new_part.id}) is under Subteam Assembly '{parent_assembly.name}' (ID: {parent_assembly.id}). Attempting to add its name to Airtable Subsystem field options.")
                 try:
-                    success = add_option_to_airtable_subsystem_field(new_part.name)
+                    success = add_option_to_airtable_subsystem_field(new_part.name, project)
                     if success:
                         app.logger.info(f"Successfully ensured '{new_part.name}' is an option in Airtable Subsystem field.")
                     else:

--- a/backend/migrations/versions/e208ae9b06c8_add_airtable_keys_to_project.py
+++ b/backend/migrations/versions/e208ae9b06c8_add_airtable_keys_to_project.py
@@ -1,0 +1,26 @@
+"""add airtable keys to project
+
+Revision ID: e208ae9b06c8
+Revises: 73abed0cd67c
+Create Date: 2025-07-29 02:50:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'e208ae9b06c8'
+down_revision = '73abed0cd67c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('projects', sa.Column('airtable_api_key', sa.String(length=100), nullable=True))
+    op.add_column('projects', sa.Column('airtable_base_id', sa.String(length=50), nullable=True))
+    op.add_column('projects', sa.Column('airtable_table_id', sa.String(length=50), nullable=True))
+
+
+def downgrade():
+    op.drop_column('projects', 'airtable_table_id')
+    op.drop_column('projects', 'airtable_base_id')
+    op.drop_column('projects', 'airtable_api_key')

--- a/backend/tests/test_airtable_service.py
+++ b/backend/tests/test_airtable_service.py
@@ -204,7 +204,7 @@ class TestAirtableService:
             result = add_option_to_airtable_subsystem_field('New Subsystem')
             
             assert result is True
-            mock_typecast.assert_called_once_with('New Subsystem', AIRTABLE_SUBSYSTEM)
+            mock_typecast.assert_called_once_with('New Subsystem', AIRTABLE_SUBSYSTEM, project=None)
 
     @pytest.mark.unit
     @patch('app.services.airtable_service.add_option_via_typecast')


### PR DESCRIPTION
## Summary
- allow storing Airtable credentials on `Project`
- endpoint for admins to update a project's Airtable API keys
- use project credentials when syncing parts to Airtable
- update tests
- migration for new columns

## Testing
- `pytest -q` *(fails: 35 failed, 29 passed, 161 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688835d985888322bdbbc06a6cfb27bf